### PR TITLE
Only load fallback when needed

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
-const fallback = require('./fallback')
-
 try {
   const native = require('quickbit-native')
 
@@ -11,5 +9,5 @@ try {
   exports.findLast = native.findLast
   exports.Index = native.Index
 } catch {
-  module.exports = fallback
+  module.exports = require('./fallback')
 }


### PR DESCRIPTION
Dunno if the fallback is loaded eagerly for a reason, but the fallback uses another native binding, simdle-native, so that one gets always loaded atm, without being used if the native binding is used.